### PR TITLE
Fix Manifest Generation on Windows

### DIFF
--- a/config/stimulus-laravel.php
+++ b/config/stimulus-laravel.php
@@ -3,7 +3,7 @@
 use HotwiredLaravel\StimulusLaravel\Features;
 
 return [
-    'controllers_path' => resource_path(join(DIRECTORY_SEPARATOR, ['js', 'controllers'])),
+    'controllers_path' => resource_path(implode(DIRECTORY_SEPARATOR, ['js', 'controllers'])),
     'features' => [
         Features::directives(),
     ],

--- a/config/stimulus-laravel.php
+++ b/config/stimulus-laravel.php
@@ -3,7 +3,7 @@
 use HotwiredLaravel\StimulusLaravel\Features;
 
 return [
-    'controllers_path' => resource_path('js/controllers'),
+    'controllers_path' => resource_path(join(DIRECTORY_SEPARATOR, ['js', 'controllers'])),
     'features' => [
         Features::directives(),
     ],

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -16,15 +16,15 @@ class Manifest
             ->values()
             ->map(function (SplFileInfo $file) use ($controllersPath) {
                 $controllerPath = $this->relativePathFrom($file->getRealPath(), $controllersPath);
-                $modulePath = Str::before($controllerPath, '.');
+                $modulePath = Str::of($controllerPath)->before('.')->replace(DIRECTORY_SEPARATOR, '/')->toString();
                 $controllerClassName = Str::of($modulePath)
-                    ->explode(DIRECTORY_SEPARATOR)
+                    ->explode('/')
                     ->map(fn ($piece) => Str::studly($piece))
                     ->join('__');
-                $tagName = Str::of($modulePath)->before('_controller')->replace('_', '-')->replace(DIRECTORY_SEPARATOR, '--')->toString();
+                $tagName = Str::of($modulePath)->before('_controller')->replace('_', '-')->replace('/', '--')->toString();
 
                 $join = function ($paths) {
-                    return implode(DIRECTORY_SEPARATOR, $paths);
+                    return implode('/', $paths);
                 };
 
                 return <<<JS

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -9,14 +9,14 @@ class ManifestTest extends TestCase
     /** @test */
     public function generates_controllers_imports_given_a_path()
     {
-        $manifest = (new Manifest)->generateFrom(join(DIRECTORY_SEPARATOR, [
+        $manifest = (new Manifest)->generateFrom(implode(DIRECTORY_SEPARATOR, [
             __DIR__,
             'stubs',
             'controllers',
         ]).DIRECTORY_SEPARATOR)->join(PHP_EOL);
 
         $this->assertStringContainsString(
-            <<<JS
+            <<<'JS'
 
             import HelloController from './hello_controller'
             application.register('hello', HelloController)
@@ -25,7 +25,7 @@ class ManifestTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            <<<JS
+            <<<'JS'
 
             import Nested__DeepController from './nested/deep_controller'
             application.register('nested--deep', Nested__DeepController)
@@ -34,7 +34,7 @@ class ManifestTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            <<<JS
+            <<<'JS'
 
             import CoffeeController from './coffee_controller'
             application.register('coffee', CoffeeController)
@@ -43,7 +43,7 @@ class ManifestTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            <<<JS
+            <<<'JS'
 
             import TypeScriptController from './type_script_controller'
             application.register('type-script', TypeScriptController)
@@ -52,7 +52,7 @@ class ManifestTest extends TestCase
         );
 
         $this->assertStringNotContainsString(
-            <<<JS
+            <<<'JS'
 
             import Index from './index'
             application.register('index', Index)

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -9,10 +9,7 @@ class ManifestTest extends TestCase
     /** @test */
     public function generates_controllers_imports_given_a_path()
     {
-        $join = function ($paths) {
-            return implode(DIRECTORY_SEPARATOR, $paths);
-        };
-        $manifest = (new Manifest)->generateFrom($join([
+        $manifest = (new Manifest)->generateFrom(join(DIRECTORY_SEPARATOR, [
             __DIR__,
             'stubs',
             'controllers',
@@ -21,7 +18,7 @@ class ManifestTest extends TestCase
         $this->assertStringContainsString(
             <<<JS
 
-            import HelloController from '{$join(['.', 'hello_controller'])}'
+            import HelloController from './hello_controller'
             application.register('hello', HelloController)
             JS,
             $manifest,
@@ -30,7 +27,7 @@ class ManifestTest extends TestCase
         $this->assertStringContainsString(
             <<<JS
 
-            import Nested__DeepController from '{$join(['.', 'nested', 'deep_controller'])}'
+            import Nested__DeepController from './nested/deep_controller'
             application.register('nested--deep', Nested__DeepController)
             JS,
             $manifest,
@@ -39,7 +36,7 @@ class ManifestTest extends TestCase
         $this->assertStringContainsString(
             <<<JS
 
-            import CoffeeController from '{$join(['.', 'coffee_controller'])}'
+            import CoffeeController from './coffee_controller'
             application.register('coffee', CoffeeController)
             JS,
             $manifest,
@@ -48,7 +45,7 @@ class ManifestTest extends TestCase
         $this->assertStringContainsString(
             <<<JS
 
-            import TypeScriptController from '{$join(['.', 'type_script_controller'])}'
+            import TypeScriptController from './type_script_controller'
             application.register('type-script', TypeScriptController)
             JS,
             $manifest,
@@ -57,7 +54,7 @@ class ManifestTest extends TestCase
         $this->assertStringNotContainsString(
             <<<JS
 
-            import Index from '{$join(['.', 'index'])}'
+            import Index from './index'
             application.register('index', Index)
             JS,
             $manifest,


### PR DESCRIPTION
### Fixed

- Fixes the `controllers_path` config not using DIRECTORY_SEPARATOR
- Fixes the generated manifest can use forward slashes `/`, since it will be compiled by Vite 

---

fixes https://github.com/hotwired-laravel/stimulus-laravel/issues/14