### PR TITLE
Support Strada

### DIFF
--- a/src/Commands/Concerns/InstallsForImportmap.php
+++ b/src/Commands/Concerns/InstallsForImportmap.php
@@ -46,7 +46,9 @@ trait InstallsForImportmap
     {
         $this->components->task('pinning JS dependency (importmap)', function () {
             $this->callSilently('importmap:pin', [
-                'packages' => ['@hotwired/stimulus'],
+                'packages' => collect($this->jsPackages())
+                    ->map(fn ($package, $version) => "{$package}@{$version}")
+                    ->all(),
             ]);
 
             // Publishes the `@hotwired/stimulus-loading` package to public/

--- a/src/Commands/Concerns/InstallsForNode.php
+++ b/src/Commands/Concerns/InstallsForNode.php
@@ -53,9 +53,10 @@ trait InstallsForNode
     {
         $this->components->task('registering NPM dependency', function () {
             $this->updateNodePackages(function ($packages) {
-                return [
-                    '@hotwired/stimulus' => '^3.1.0',
-                ] + $packages;
+                return array_merge(
+                    $packages,
+                    $this->jsPackages(),
+                );
             });
 
             return true;

--- a/src/Commands/Concerns/InstallsForNode.php
+++ b/src/Commands/Concerns/InstallsForNode.php
@@ -58,8 +58,6 @@ trait InstallsForNode
                 ] + $packages;
             });
 
-            $this->afterMessages[] = '<fg=white>Run: `<fg=yellow>npm install && npm run dev</>`</>';
-
             return true;
         });
     }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -4,8 +4,8 @@ namespace HotwiredLaravel\StimulusLaravel\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
-use Symfony\Component\Process\Process;
 use RuntimeException;
+use Symfony\Component\Process\Process;
 
 class InstallCommand extends Command
 {

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -12,7 +12,7 @@ class InstallCommand extends Command
     use Concerns\InstallsForImportmap;
     use Concerns\InstallsForNode;
 
-    public $signature = 'stimulus:install';
+    public $signature = 'stimulus:install {--strada : Sets up Strada as well.}';
 
     public $description = 'Installs the Stimulus Laravel package.';
 
@@ -43,6 +43,13 @@ class InstallCommand extends Command
         return self::SUCCESS;
     }
 
+    protected function jsPackages(): array
+    {
+        return array_merge(
+            ['@hotwired/stimulus' => '^3.1.0'],
+            $this->hasOption('strada') ? ['@hotwired/strada' => '^1.0.0-beta1'] : [],
+        );
+    }
 
     /**
      * Run the given commands.

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -4,6 +4,8 @@ namespace HotwiredLaravel\StimulusLaravel\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
+use RuntimeException;
 
 class InstallCommand extends Command
 {
@@ -24,19 +26,45 @@ class InstallCommand extends Command
             $this->installsForImportmaps();
         } else {
             $this->installsForNode();
-        }
 
-        if (! empty($this->afterMessages)) {
-            $this->newLine();
-            $this->components->info('After Notes and Next Steps');
-            $this->components->bulletList($this->afterMessages);
-        } else {
-            $this->components->info('Done');
+            if (file_exists(base_path('pnpm-lock.yaml'))) {
+                $this->runCommands(['pnpm install', 'pnpm run build']);
+            } elseif (file_exists(base_path('yarn.lock'))) {
+                $this->runCommands(['yarn install', 'yarn run build']);
+            } else {
+                $this->runCommands(['npm install', 'npm run build']);
+            }
         }
 
         $this->newLine();
+        $this->components->info('Done');
+        $this->newLine();
 
         return self::SUCCESS;
+    }
+
+
+    /**
+     * Run the given commands.
+     *
+     * @param  array  $commands
+     * @return void
+     */
+    protected function runCommands($commands)
+    {
+        $process = Process::fromShellCommandline(implode(' && ', $commands), null, null, null, null);
+
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            try {
+                $process->setTty(true);
+            } catch (RuntimeException $e) {
+                $this->output->writeln('  <bg=yellow;fg=black> WARN </> '.$e->getMessage().PHP_EOL);
+            }
+        }
+
+        $process->run(function ($type, $line) {
+            $this->output->write('    '.$line);
+        });
     }
 
     protected function usingImportmaps(): bool

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -5,6 +5,7 @@ namespace HotwiredLaravel\StimulusLaravel\Commands;
 use HotwiredLaravel\StimulusLaravel\StimulusGenerator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
 
 class MakeCommand extends Command
 {
@@ -26,6 +27,14 @@ class MakeCommand extends Command
             $this->components->task('regenerating manifest', function () {
                 return $this->callSilently(ManifestCommand::class);
             });
+
+            if (file_exists(base_path('pnpm-lock.yaml'))) {
+                Process::forever()->path(base_path())->run(['pnpm', 'run', 'build']);
+            } elseif (file_exists(base_path('yarn.lock'))) {
+                Process::forever()->path(base_path())->run(['yarn', 'run', 'build']);
+            } else {
+                Process::forever()->path(base_path())->run(['npm', 'run', 'build']);
+            }
         }
 
         $this->newLine();

--- a/src/Commands/ManifestCommand.php
+++ b/src/Commands/ManifestCommand.php
@@ -31,7 +31,7 @@ class ManifestCommand extends Command
             // Run that command whenever you add a new controller or create them with
             // `php artisan stimulus:make controllerName`
 
-            import { application } from '../libs/stimulus'
+            import { Stimulus } from '../libs/stimulus'
 
             {$manifest}
             JS);

--- a/src/Commands/StradaMakeCommand.php
+++ b/src/Commands/StradaMakeCommand.php
@@ -5,6 +5,7 @@ namespace HotwiredLaravel\StimulusLaravel\Commands;
 use HotwiredLaravel\StimulusLaravel\StimulusGenerator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
 
 class StradaMakeCommand extends Command
 {
@@ -29,6 +30,14 @@ class StradaMakeCommand extends Command
             $this->components->task('regenerating manifest', function () {
                 return $this->callSilently(ManifestCommand::class);
             });
+
+            if (file_exists(base_path('pnpm-lock.yaml'))) {
+                Process::forever()->path(base_path())->run(['pnpm', 'run', 'build']);
+            } elseif (file_exists(base_path('yarn.lock'))) {
+                Process::forever()->path(base_path())->run(['yarn', 'run', 'build']);
+            } else {
+                Process::forever()->path(base_path())->run(['npm', 'run', 'build']);
+            }
         }
 
         $this->newLine();

--- a/src/Commands/StradaMakeCommand.php
+++ b/src/Commands/StradaMakeCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace HotwiredLaravel\StimulusLaravel\Commands;
+
+use HotwiredLaravel\StimulusLaravel\StimulusGenerator;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class StradaMakeCommand extends Command
+{
+    public $signature = 'strada:make
+                            {name : The Strada Component name (without bridge prefix.}
+                            {--prefix=bridge : The component prefix.}
+                            {--bridge-name= : The name of the native component.}';
+
+    public $description = 'Makes a new Strada Component.';
+
+    public function handle(StimulusGenerator $generator): int
+    {
+        $this->components->info('Making Strada Component');
+
+        $this->components->task('creating strada component', function () use ($generator) {
+            $generator->createStrada($this->option('prefix'), $this->argument('name'), $this->option('bridge-name'));
+
+            return true;
+        });
+
+        if (! File::exists(base_path('routes/importmap.php'))) {
+            $this->components->task('regenerating manifest', function () {
+                return $this->callSilently(ManifestCommand::class);
+            });
+        }
+
+        $this->newLine();
+        $this->components->info('Done');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -30,7 +30,7 @@ class Manifest
                 return <<<JS
 
                 import {$controllerClassName} from '{$join(['.', $modulePath])}'
-                application.register('{$tagName}', {$controllerClassName})
+                Stimulus.register('{$tagName}', {$controllerClassName})
                 JS;
             });
     }

--- a/src/StimulusGenerator.php
+++ b/src/StimulusGenerator.php
@@ -41,7 +41,7 @@ class StimulusGenerator
         return $this->create("$prefix/$name", stub: __DIR__.'/../stubs/strada.stub', replacementsCallback: function (array $replacements) use ($bridgeName) {
             return array_merge(
                 $replacements,
-                ['[bridge-name]' => $bridgeName ?? (string) Str::of($replacements['[attribute]'])->afterLast('/')],
+                ['[bridge-name]' => $bridgeName ?? (string) Str::of($replacements['[attribute]'])->afterLast('--')],
             );
         });
     }

--- a/src/StimulusGenerator.php
+++ b/src/StimulusGenerator.php
@@ -12,16 +12,21 @@ class StimulusGenerator
         $this->targetFolder ??= rtrim(resource_path('js/controllers'), '/');
     }
 
-    public function create(string $name): array
+    public function create(string $name, string $stub = null, callable $replacementsCallback = null): array
     {
+        $replacementsCallback ??= fn ($replacements) => $replacements;
         $controllerName = $this->controllerName($name);
         $targetFile = $this->targetFolder.'/'.$controllerName.'_controller.js';
 
         File::ensureDirectoryExists(dirname($targetFile));
 
+        $replacements = $replacementsCallback([
+            '[attribute]' => $attributeName = $this->attributeName($name),
+        ]);
+
         File::put(
             $targetFile,
-            str_replace('[attribute]', $attributeName = $this->attributeName($name), File::get(__DIR__.'/../stubs/controller.stub')),
+            str_replace(array_keys($replacements), array_values($replacements), File::get($stub ?: __DIR__.'/../stubs/controller.stub')),
         );
 
         return [
@@ -29,6 +34,16 @@ class StimulusGenerator
             'controller_name' => $controllerName,
             'attribute_name' => $attributeName,
         ];
+    }
+
+    public function createStrada(string $prefix, string $name, string $bridgeName = null): array
+    {
+        return $this->create("$prefix/$name", stub: __DIR__.'/../stubs/strada.stub', replacementsCallback: function (array $replacements) use ($bridgeName) {
+            return array_merge(
+                $replacements,
+                ['[bridge-name]' => $bridgeName ?? (string) Str::of($replacements['[attribute]'])->afterLast('/')],
+            );
+        });
     }
 
     private function controllerName(string $name): string

--- a/src/StimulusLaravelServiceProvider.php
+++ b/src/StimulusLaravelServiceProvider.php
@@ -22,6 +22,7 @@ class StimulusLaravelServiceProvider extends PackageServiceProvider
             ->hasCommands([
                 Commands\InstallCommand::class,
                 Commands\MakeCommand::class,
+                Commands\StradaMakeCommand::class,
                 Commands\CoreMakeCommand::class,
                 Commands\PublishCommand::class,
                 Commands\ManifestCommand::class,

--- a/stubs/resources/js/controllers/index-importmap.js
+++ b/stubs/resources/js/controllers/index-importmap.js
@@ -1,5 +1,5 @@
-import { application } from 'libs/stimulus'
+import { Stimulus } from 'libs/stimulus'
 
 // Eager load all controllers defined in the import map under controllers/**/*_controller
 import { eagerLoadControllersFrom } from '@hotwired/stimulus-loading'
-eagerLoadControllersFrom('controllers', application)
+eagerLoadControllersFrom('controllers', Stimulus)

--- a/stubs/resources/js/controllers/index-node.js
+++ b/stubs/resources/js/controllers/index-node.js
@@ -2,7 +2,7 @@
 // Run that command whenever you add a new controller or create them with
 // `php artisan stimulus:make controllerName`
 
-import { application } from '../libs/stimulus'
+import { Stimulus } from '../libs/stimulus'
 
 import HelloController from './hello_controller'
-application.register('hello', HelloController)
+Stimulus.register('hello', HelloController)

--- a/stubs/resources/js/libs/stimulus.js
+++ b/stubs/resources/js/libs/stimulus.js
@@ -3,7 +3,8 @@ import { Application } from '@hotwired/stimulus'
 const Stimulus = Application.start()
 
 // Configure Stimulus development experience
-application.debug = false
-window.Stimulus   = Stimulus
+Stimulus.debug = false
+
+window.Stimulus = Stimulus
 
 export { Stimulus }

--- a/stubs/resources/js/libs/stimulus.js
+++ b/stubs/resources/js/libs/stimulus.js
@@ -1,9 +1,9 @@
 import { Application } from '@hotwired/stimulus'
 
-const application = Application.start()
+const Stimulus = Application.start()
 
 // Configure Stimulus development experience
 application.debug = false
-window.Stimulus   = application
+window.Stimulus   = Stimulus
 
-export { application }
+export { Stimulus }

--- a/stubs/strada.stub
+++ b/stubs/strada.stub
@@ -1,0 +1,8 @@
+import { BridgeComponent, BridgeElement } from "@hotwired/strada"
+
+// Connects to data-controller="[attribute]"
+export default class extends BridgeComponent {
+    static component = "[bridge-name]"
+
+    //
+}

--- a/tests/ManifestTest.php
+++ b/tests/ManifestTest.php
@@ -19,7 +19,7 @@ class ManifestTest extends TestCase
             <<<'JS'
 
             import HelloController from './hello_controller'
-            application.register('hello', HelloController)
+            Stimulus.register('hello', HelloController)
             JS,
             $manifest,
         );
@@ -28,7 +28,7 @@ class ManifestTest extends TestCase
             <<<'JS'
 
             import Nested__DeepController from './nested/deep_controller'
-            application.register('nested--deep', Nested__DeepController)
+            Stimulus.register('nested--deep', Nested__DeepController)
             JS,
             $manifest,
         );
@@ -37,7 +37,7 @@ class ManifestTest extends TestCase
             <<<'JS'
 
             import CoffeeController from './coffee_controller'
-            application.register('coffee', CoffeeController)
+            Stimulus.register('coffee', CoffeeController)
             JS,
             $manifest,
         );
@@ -46,7 +46,7 @@ class ManifestTest extends TestCase
             <<<'JS'
 
             import TypeScriptController from './type_script_controller'
-            application.register('type-script', TypeScriptController)
+            Stimulus.register('type-script', TypeScriptController)
             JS,
             $manifest,
         );
@@ -55,7 +55,7 @@ class ManifestTest extends TestCase
             <<<'JS'
 
             import Index from './index'
-            application.register('index', Index)
+            Stimulus.register('index', Index)
             JS,
             $manifest,
         );


### PR DESCRIPTION
### Added

- Adds a new `--strada` option to the `stimulus:install` command that also pulls the `@hotwired/strada` dependency
- Adds a new `strada:make` command that generates (and registers) strada components

### Changed

- Tweaks the base `libs/stimulus.js` so it exports a `{ Stimulus }` module instead of `{ application }` and updates the generators accordingly